### PR TITLE
improve wifi reconnect

### DIFF
--- a/bridge/lib/display_driver.py
+++ b/bridge/lib/display_driver.py
@@ -60,7 +60,7 @@ class LCD_Display:
         self.update_intvl = None
         self.brightness = None  # getattr
         self.indicator = True
-        self.startup_msg = ""
+        self.startup_msg = []
         # lcd = PicoGraphics(display=DISPLAY_PICO_DISPLAY, pen_type=PEN_P4,rotate=0)
         # lcd.set_backlight(1.0)
         # update_frequency = 3 # seconds to cycle through each screen
@@ -338,18 +338,44 @@ class LCD_Display:
         self.indicator = not self.indicator
         self.lcd.circle(10, 60, 5) # x, y, r
     
-    def show_msg(self, msg):
+    def show_msg(self, msg, append=True):
         #self.lcd.set_font("serif")
-        self.startup_msg = self.startup_msg + "\n" + msg
+        if append:
+            #self.startup_msg = self.startup_msg + "\n" + msg
+            try:
+                self.startup_msg.append(msg)
+            except NameError:
+                self.startup_msg = [msg]
+        else:
+            # overwrite last line
+            #self.overwrite_msg(msg)
+            try:
+                self.startup_msg[-1] = msg
+            except NameError:
+                self.startup_msg = [msg]
         self.lcd.set_font("bitmap8")
         self.lcd.set_pen(self.colour_to_palette["BG"])
         self.lcd.clear()
         self.lcd.set_thickness(1)
         self.lcd.set_pen(self.colour_to_palette["WHITE"])
         #self.lcd.text(msg, 0, 65, scale=1)
-        self.lcd.text(self.startup_msg, 0, 0)
+        #self.lcd.text(self.startup_msg, 0, 0)
+        self.lcd.text('\n'.join([item for item in self.startup_msg]), 0, 0)
         self.lcd.update()
         time.sleep(1)
+    
+    '''def overwrite_msg(self, new_msg):
+        # overwrite the last line of a messgae
+        import re
+        regex = re.compile("[\n]")
+        msgs = regex.split(self.startup_msg)
+        if len(msgs)>0:
+            msgs[len(msgs)-1] = new_msg
+        else:
+            msgs[0] = new_msg
+        self.startup_msg = '\n'.join([item for item in msgs])
+        '''
+        
 
 class RGB_Driver:
     def __new__(cls, config: BridgeConfig):
@@ -409,4 +435,4 @@ def r_align(lcd_obj, txt, sz, width):
     return int(width - lcd_obj.measure_text(txt, sz))
 
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/bridge/lib/wifi_client.py
+++ b/bridge/lib/wifi_client.py
@@ -46,54 +46,75 @@ class WifiClient:
 
     async def wifi_connect(self, onboard_led, quick=False):
         await onboard_led.set_status(onboard_led.WIFI_CONNECTING)
-        s = self._sta_if
-        s.active(True)
+        nic = self._sta_if
+        nic.active(True)
         if RP2:  # Disable auto-sleep.
             # https://datasheets.raspberrypi.com/picow/connecting-to-the-internet-with-pico-w.pdf
             # para 3.6.3
-            s.config(pm=0xA11140)
+            nic.config(pm=0xA11140)
             import rp2
 
             if self._country:
                 rp2.country(self._country)
         logger.info("Attempting to connect to wifi")
-        s.connect(self._ssid, self._wifi_pw)
+        nic.connect(self._ssid, self._wifi_pw)
         for _ in range(60):  # Break out on fail or success. Check once per sec.
             await asyncio.sleep(1)
             # Loop while connecting or no IP
-            if s.isconnected():
+            if nic.isconnected():
                 logger.info("wifi connected")
                 await onboard_led.set_status(onboard_led.WIFI_CONNECTED)
                 break
             if RP2:  # 1 is joining. 2 is No IP, ie in process of connecting
-                if not 1 <= s.status() <= 3:
-                    logger.debug(f"wifi reports {error_codes_to_messages[s.status()]}")
+                if not 1 <= nic.status() <= 3:
+                    logger.warning(f"wifi reports {error_codes_to_messages[nic.status()]}")
                     break
         else:  # Timeout: still in connecting state
-            s.disconnect()
+            nic.disconnect()
+            nic.active(False)
             await onboard_led.set_status(onboard_led.WIFI_DISCONNECTED)
             await asyncio.sleep(1)
-
-        if not s.isconnected():  # Timed out
-            logger.warning("wifi connect timed out")
-            raise OSError("Wi-Fi connect timed out")
-        if not quick:  # Skip on first connection only if power saving
-            # Ensure connection stays up for a few secs.
-            logger.info("Checking wifi integrity")
-            for _ in range(5):
-                if not s.isconnected():
-                    logger.warning("Connection Unstable")
-                    raise OSError("Connection Unstable")  # in 1st 5 secs
-                await asyncio.sleep(1)
-            logger.info("Got reliable connection")
+            #if not nic.isconnected():  # Timed out
+            logger.warning(f"wifi connect timed out {error_codes_to_messages[nic.status()]}")
+            #raise OSError("Wi-Fi connect timed out")
+        #else:
+        if nic.isconnected():
+            if not quick:  # Skip on first connection only if power saving
+                # Ensure connection stays up for a few secs.
+                logger.info("Checking wifi integrity")
+                for _ in range(5):
+                    if not nic.isconnected():
+                        logger.warning("Connection Unstable")
+                        #raise OSError("Connection Unstable")  # in 1st 5 secs
+                    await asyncio.sleep(1)
+                logger.info("Got reliable connection")
+        return nic.status()
 
     async def connect(
-        self, onboard_led, quick=False
+        self, onboard_led, display=False, quick=False
     ):  # Quick initial connect option for battery apps
-        s = self._sta_if
-        if not s.isconnected():
-            await self.wifi_connect(onboard_led, quick)
-        if s.isconnected():
+        nic = self._sta_if
+        attempt = 0
+        while not nic.isconnected():
+            attempt += 1
+            result = await self.wifi_connect(onboard_led, quick)
+            if result < 0:
+                # wifi not connected
+                if display:
+                    display.show_msg(f"{error_codes_to_messages[result]} ({attempt})", append = (False if attempt>1 else True))
+                if result == -3:
+                    if display:
+                        display.show_msg("bad wifi password,\nstopping here.")
+                    logger.error("bad wifi password, stopping here.")
+                    raise OSError("Bad Password")
+                else:
+                    logger.debug("sleep 120 secs and try wifi again")
+                    if display:
+                        display.show_msg("trying again in 2 minutes.")
+                        del display.startup_msg[-1] #remove that last message from list - it's a hack
+                    await asyncio.sleep(12)
+                
+        if nic.isconnected():
             if self.check_interval > 0:
                 asyncio.create_task(self._keep_connected())
                 # Runs forever unless user issues .disconnect()
@@ -103,10 +124,10 @@ class WifiClient:
     # Scheduled on 1st successful connection. Runs forever maintaining wifi and
     # broker connection. Must handle conditions at edge of wifi range.
     async def _keep_connected(self):
-        s = self._sta_if
-        while True:  # s.active():
+        nic = self._sta_if
+        while True:  # nic.active():
             logger.debug("running in _keep_connected")
-            if s.isconnected():  # Pause for 1 second
+            if nic.isconnected():  # Pause for 1 second
                 # await asyncio.sleep(1) # debug
                 await asyncio.sleep(
                     randrange(
@@ -116,7 +137,7 @@ class WifiClient:
                 gc.collect()
             else:  # Link is down
                 try:
-                    s.disconnect()
+                    nic.disconnect()
                 except OSError:
                     logger.error("Wi-Fi not started, unable to disconnect interface")
                 await asyncio.sleep(1)
@@ -131,7 +152,7 @@ class WifiClient:
                 except OSError as e:
                     logger.error(f"Error in reconnect. {e}")
                     # Can get ECONNABORTED or -1. The latter signifies no or bad CONNACK received.
-                    s.disconnect()
+                    nic.disconnect()
         logger.warning("Disconnected, exited _keep_connected")
 
 
@@ -160,4 +181,4 @@ async def wan_ok(
     return False
 
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/bridge/lib/wifi_client.py
+++ b/bridge/lib/wifi_client.py
@@ -112,7 +112,7 @@ class WifiClient:
                     if display:
                         display.show_msg("trying again in 2 minutes.")
                         del display.startup_msg[-1] #remove that last message from list - it's a hack
-                    await asyncio.sleep(12)
+                    await asyncio.sleep(120)
                 
         if nic.isconnected():
             if self.check_interval > 0:

--- a/bridge/lib/wifi_client.py
+++ b/bridge/lib/wifi_client.py
@@ -12,7 +12,7 @@ from random import randrange
 from sys import platform
 
 RP2 = platform == "rp2"
-
+'''
 # cyw43_wifi_link_status
 error_codes_to_messages = {
     0: "CYW43_LINK_DOWN",
@@ -22,6 +22,16 @@ error_codes_to_messages = {
     -1: "CYW43_LINK_FAIL",
     -2: "CYW43_LINK_NONET",
     -3: "CYW43_LINK_BADAUTH",
+}'''
+# cyw43_wifi_link_status
+error_codes_to_messages = {
+    0: "STAT_IDLE",
+    1: "STAT_CONNECTING",
+    2: "STAT_GOT_IP",
+    3: "CYW43_LINK_UP",
+    -1: "STAT_CONNECT_FAIL",
+    -2: "STAT_NO_AP_FOUND",
+    -3: "STAT_WRONG_PASSWORD",
 }
 
 logger = logging.getLogger(__name__)
@@ -33,7 +43,7 @@ class WifiClient:
         # self._ping_interval = 20000
         # self._in_connect = False
         # self._has_connected = False  # Define 'Clean Session' value to use.
-        self._sta_if = network.WLAN(network.STA_IF)
+        self.nic = network.WLAN(network.STA_IF)
         self._ssid = config.ssid
         self._wifi_pw = config.password
         try:
@@ -46,59 +56,76 @@ class WifiClient:
 
     async def wifi_connect(self, onboard_led, quick=False):
         await onboard_led.set_status(onboard_led.WIFI_CONNECTING)
-        nic = self._sta_if
-        nic.active(True)
-        if RP2:  # Disable auto-sleep.
+        #nic = self._sta_if
+        #nic.disconnect()
+        #nic.active(False)
+        '''if RP2:  # Disable auto-sleep.
             # https://datasheets.raspberrypi.com/picow/connecting-to-the-internet-with-pico-w.pdf
             # para 3.6.3
             nic.config(pm=0xA11140)
             import rp2
 
             if self._country:
-                rp2.country(self._country)
+                rp2.country(self._country)'''
+        self.nic.deinit()
+        self.nic = network.WLAN(network.STA_IF)
+        network.hostname("tilt_micro_bridge")
+        self.nic.config(pm = network.WLAN.PM_PERFORMANCE)
+        if self._country:
+            network.country(self._country)
         logger.info("Attempting to connect to wifi")
-        nic.connect(self._ssid, self._wifi_pw)
-        for _ in range(60):  # Break out on fail or success. Check once per sec.
-            await asyncio.sleep(1)
+        self.nic.active(True)
+        self.nic.connect(self._ssid, self._wifi_pw)
+        catch = 0
+        for _ in range(30):  # Break out on fail or success. Check once per sec.
+            catch = self.nic.status() # can be a fleeting status, so capture it
+            # print(catch)
             # Loop while connecting or no IP
-            if nic.isconnected():
+            if self.nic.isconnected():
                 logger.info("wifi connected")
                 await onboard_led.set_status(onboard_led.WIFI_CONNECTED)
                 break
-            if RP2:  # 1 is joining. 2 is No IP, ie in process of connecting
-                if not 1 <= nic.status() <= 3:
-                    logger.warning(f"wifi reports {error_codes_to_messages[nic.status()]}")
-                    break
+            #if RP2:  # 1 is joining. 2 is No IP, ie in process of connecting
+            #    if not 1 <= nic.status() <= 3:
+            if catch < 1:
+                logger.warning(f"wifi reports {error_codes_to_messages[catch]}")
+                break
+            await asyncio.sleep(1)
         else:  # Timeout: still in connecting state
-            nic.disconnect()
-            nic.active(False)
             await onboard_led.set_status(onboard_led.WIFI_DISCONNECTED)
             await asyncio.sleep(1)
             #if not nic.isconnected():  # Timed out
-            logger.warning(f"wifi connect timed out {error_codes_to_messages[nic.status()]}")
+            logger.warning(f"wifi connect timed out {error_codes_to_messages[catch]}")
             #raise OSError("Wi-Fi connect timed out")
         #else:
-        if nic.isconnected():
+        if self.nic.isconnected():
             if not quick:  # Skip on first connection only if power saving
                 # Ensure connection stays up for a few secs.
                 logger.info("Checking wifi integrity")
                 for _ in range(5):
-                    if not nic.isconnected():
+                    if not self.nic.isconnected():
                         logger.warning("Connection Unstable")
                         #raise OSError("Connection Unstable")  # in 1st 5 secs
                     await asyncio.sleep(1)
                 logger.info("Got reliable connection")
-        return nic.status()
+        else:  # reset nic
+            self.nic.disconnect()
+            self.nic.active(False)
+            self.nic.deinit()
+        return catch #nic.status()
 
     async def connect(
         self, onboard_led, display=False, quick=False
     ):  # Quick initial connect option for battery apps
-        nic = self._sta_if
+        #nic = self._sta_if
         attempt = 0
-        while not nic.isconnected():
+        while not self.nic.isconnected():
+            if attempt > 0 and display:
+                display.show_msg("trying connection again")
+                del display.startup_msg[-1]
             attempt += 1
             result = await self.wifi_connect(onboard_led, quick)
-            if result < 0:
+            if result < 2:
                 # wifi not connected
                 if display:
                     display.show_msg(f"{error_codes_to_messages[result]} ({attempt})", append = (False if attempt>1 else True))
@@ -111,10 +138,10 @@ class WifiClient:
                     logger.debug("sleep 120 secs and try wifi again")
                     if display:
                         display.show_msg("trying again in 2 minutes.")
-                        del display.startup_msg[-1] #remove that last message from list - it's a hack
+                        del display.startup_msg[-1] #remove that last message from list - it's hacky
                     await asyncio.sleep(120)
                 
-        if nic.isconnected():
+        if self.nic.isconnected():
             if self.check_interval > 0:
                 asyncio.create_task(self._keep_connected())
                 # Runs forever unless user issues .disconnect()
@@ -124,10 +151,10 @@ class WifiClient:
     # Scheduled on 1st successful connection. Runs forever maintaining wifi and
     # broker connection. Must handle conditions at edge of wifi range.
     async def _keep_connected(self):
-        nic = self._sta_if
+        #nic = self._sta_if
         while True:  # nic.active():
             logger.debug("running in _keep_connected")
-            if nic.isconnected():  # Pause for 1 second
+            if self.nic.isconnected():  # Pause for 1 second
                 # await asyncio.sleep(1) # debug
                 await asyncio.sleep(
                     randrange(
@@ -137,7 +164,7 @@ class WifiClient:
                 gc.collect()
             else:  # Link is down
                 try:
-                    nic.disconnect()
+                    self.nic.disconnect()
                 except OSError:
                     logger.error("Wi-Fi not started, unable to disconnect interface")
                 await asyncio.sleep(1)
@@ -152,7 +179,7 @@ class WifiClient:
                 except OSError as e:
                     logger.error(f"Error in reconnect. {e}")
                     # Can get ECONNABORTED or -1. The latter signifies no or bad CONNACK received.
-                    nic.disconnect()
+                    self.nic.disconnect()
         logger.warning("Disconnected, exited _keep_connected")
 
 
@@ -181,4 +208,4 @@ async def wan_ok(
     return False
 
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/bridge/tilt_micro_bridge.py
+++ b/bridge/tilt_micro_bridge.py
@@ -1,20 +1,3 @@
-"""latest change:
-    allow for a display rst pin
-    remove clock, introduce blinky dot
-    report some startup progress on LCD, if present
-working on:
-    1.1.1
-TODO:
-    todo refactor main & bridge lib to make more logical
-    todo remove unnecessary libs & comments
-
-ideas:
-button to set into calibration mode, use different cal_config.json ?
-display
-
-
-"""
-
 import time  # micropython-lib/python-stdlib/time extends std time module, required for strftime in debug logging
 import logging
 from logging import TimedRotatingLogFileHandler
@@ -99,12 +82,12 @@ if bridge.initialised():
     if wifi.has_config:
         if bridge.display:
             bridge.display.show_msg("connecting to wifi...")
-        asyncio.run(wifi.connect(onboard_led))
+        asyncio.run(wifi.connect(onboard_led, bridge.display))
 
-    if bridge.display:
-        bridge.display.show_msg("wifi connected \nget NTP time")
-    # set system time - could have a UTC offset in config, but time is only used internally at the moment
-    bridge.get_time()
+        if bridge.display:
+            bridge.display.show_msg("wifi connected \nget NTP time")
+        # set system time - could have a UTC offset in config, but time is only used internally at the moment
+        bridge.get_time()
     # provision the providers referenced in config.json, called here so the wifi referrnce doesn't have to be passed around
     bridge.set_providers(wifi.has_config)
 
@@ -143,4 +126,5 @@ else:
     # hold here, cannot proceed, error with config.json
     onboard_led.on()
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
+

--- a/build/boot.py
+++ b/build/boot.py
@@ -93,12 +93,12 @@ if bridge.initialised():
     if wifi.has_config:
         if bridge.display:
             bridge.display.show_msg("connecting to wifi...")
-        asyncio.run(wifi.connect(onboard_led))
+        asyncio.run(wifi.connect(onboard_led, bridge.display))
 
-    if bridge.display:
-        bridge.display.show_msg("wifi connected \\nget NTP time")
-    # set system time - could have a UTC offset in config, but time is only used internally at the moment
-    bridge.get_time()
+        if bridge.display:
+            bridge.display.show_msg("wifi connected \nget NTP time")
+        # set system time - could have a UTC offset in config, but time is only used internally at the moment
+        bridge.get_time()
     # provision the providers referenced in config.json, called here so the wifi referrnce doesn't have to be passed around
     bridge.set_providers(wifi.has_config)
 
@@ -137,7 +137,7 @@ else:
     # hold here, cannot proceed, error with config.json
     onboard_led.on()
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 """)
 

--- a/build/boot.py
+++ b/build/boot.py
@@ -96,7 +96,7 @@ if bridge.initialised():
         asyncio.run(wifi.connect(onboard_led, bridge.display))
 
         if bridge.display:
-            bridge.display.show_msg("wifi connected \nget NTP time")
+            bridge.display.show_msg("wifi connected \\nget NTP time")
         # set system time - could have a UTC offset in config, but time is only used internally at the moment
         bridge.get_time()
     # provision the providers referenced in config.json, called here so the wifi referrnce doesn't have to be passed around


### PR DESCRIPTION
make the wifi reconnection process more robust and report errors on display if present.
tilt_micro_bridge:
  pass the display objectto wifi client
  only get ntp time if we got a connection
wifi_client:
  change ref to nic
  if password is bad then stop
  otherwise retry infinitely
display_driver:
  startup_msg as a list
  append method added to show_msg (if append=False overwrite last line rather than add newline)